### PR TITLE
Add Homebrew tap support via GoReleaser and rename module to github.com/gregology/sctx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,38 @@
+version: 2
+
+builds:
+  - main: ./cmd/sctx
+    binary: sctx
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+brews:
+  - repository:
+      owner: gregology
+      name: homebrew-tap
+    homepage: "https://sctx.dev"
+    description: "Structured Context CLI — scoped context for AI agents"
+    license: "MIT"
+    install: |
+      bin.install "sctx"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Think of it as `AGENTS.md` with precision. Instead of dumping everything into on
 ## Quick start
 
 ```bash
-go install github.com/gregology/structuredcontext/cmd/sctx@latest
+go install github.com/gregology/sctx/cmd/sctx@latest
 ```
 
 Create a `CONTEXT.yaml` anywhere in your project:

--- a/cmd/sctx/main.go
+++ b/cmd/sctx/main.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gregology/structuredcontext/internal/adapter"
-	"github.com/gregology/structuredcontext/internal/core"
-	"github.com/gregology/structuredcontext/internal/validator"
+	"github.com/gregology/sctx/internal/adapter"
+	"github.com/gregology/sctx/internal/core"
+	"github.com/gregology/sctx/internal/validator"
 )
 
 const usage = `sctx — Structured Context CLI
@@ -254,7 +254,7 @@ func cmdInit() error {
 	}
 
 	content := strings.TrimSpace(`
-# Structured Context — https://github.com/gregology/structuredcontext
+# Structured Context — https://sctx.dev
 #
 # This file provides scoped context to AI agents during file operations.
 # Place CONTEXT.yaml files anywhere in your codebase. Context is inherited

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,8 +8,8 @@
 ## Getting started
 
 ```bash
-git clone https://github.com/gregology/structuredcontext.git
-cd structuredcontext
+git clone https://github.com/gregology/sctx.git
+cd sctx
 make check
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```bash
-go install github.com/gregology/structuredcontext/cmd/sctx@latest
+go install github.com/gregology/sctx/cmd/sctx@latest
 ```
 
 Make sure `~/go/bin` is in your PATH:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gregology/structuredcontext
+module github.com/gregology/sctx
 
 go 1.25.1
 

--- a/internal/adapter/claude.go
+++ b/internal/adapter/claude.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/gregology/structuredcontext/internal/core"
+	"github.com/gregology/sctx/internal/core"
 )
 
 // ClaudeHookInput represents the JSON that Claude Code sends via stdin to hooks.

--- a/internal/validator/validate.go
+++ b/internal/validator/validate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	"gopkg.in/yaml.v3"
 
-	"github.com/gregology/structuredcontext/internal/core"
+	"github.com/gregology/sctx/internal/core"
 )
 
 var contextFileNames = []string{


### PR DESCRIPTION
## Summary

Adds Homebrew tap support so users can `brew install gregology/tap/sctx`, and renames the Go module from `github.com/gregology/structuredcontext` to `github.com/gregology/sctx` to match the new repo name.

## Why Homebrew

Right now the only install path is `go install`, which means users need a Go toolchain. That's a non-starter for anyone who just wants the CLI. Homebrew is the obvious choice for macOS distribution and covers most of the target audience.

## Approach: GoReleaser + Homebrew Tap

We considered three ways to get into Homebrew:

**Homebrew Core** - the "official" route where you submit a formula to the main homebrew-core repo. Requires the project to have meaningful traction (50+ stars, established usage). We're not there yet. This is a future goal once adoption picks up.

**Manual formula + manual releases** - write a Formula by hand, build release tarballs ourselves, update the formula SHA on every release. Works but it's tedious and error-prone. Every release becomes a multi-step checklist that someone will eventually forget a step of.

**GoReleaser + Homebrew Tap** - GoReleaser already knows how to cross-compile Go binaries and create GitHub releases. It also has a built-in `brews` section that auto-generates and pushes a Homebrew formula to a tap repo on every tagged release. One `git tag` and everything flows through. This is what we went with.

The tap lives at `gregology/homebrew-tap`. GoReleaser pushes the formula there automatically via a fine-grained PAT stored as `HOMEBREW_TAP_GITHUB_TOKEN` in the repo's Actions secrets.

## Release flow

```
git tag v0.1.0 && git push origin v0.1.0
```

That's it. GitHub Actions runs GoReleaser, which builds darwin/linux binaries for amd64 and arm64, creates a GitHub release with checksums, and pushes the updated formula to the tap repo.

## Module rename

The repo moved from `gregology/structuredcontext` to `gregology/sctx`. All import paths, install commands, clone URLs, and the init template URL were updated to match.