### PR TITLE
Add sctx claude enable/disable commands to manage hook settings

### DIFF
--- a/cmd/sctx/main.go
+++ b/cmd/sctx/main.go
@@ -23,6 +23,8 @@ Usage:
   sctx decisions <path> [--json]           Query decisions for a file
   sctx validate [<dir>]                    Validate all context files in a directory tree
   sctx init                                Create a starter CONTEXT.yaml in the current directory
+  sctx claude enable                       Enable sctx hooks in Claude Code
+  sctx claude disable                      Disable sctx hooks in Claude Code
   sctx version                             Print version
 
 Actions: read, edit, create, all (default: all)
@@ -32,10 +34,11 @@ Timing:  before, after (default: before)
 var (
 	version = "dev"
 
-	errMissingPath    = errors.New("missing required <path> argument")
-	errOnNeedsValue   = errors.New("--on requires a value")
-	errWhenNeedsValue = errors.New("--when requires a value")
-	errFileExists     = errors.New("file already exists")
+	errMissingPath      = errors.New("missing required <path> argument")
+	errOnNeedsValue     = errors.New("--on requires a value")
+	errWhenNeedsValue   = errors.New("--when requires a value")
+	errFileExists       = errors.New("file already exists")
+	errClaudeSubcommand = errors.New("usage: sctx claude <enable|disable>")
 )
 
 func main() {
@@ -59,6 +62,8 @@ func main() {
 		err = cmdInit()
 	case "version":
 		fmt.Println("sctx", version)
+	case "claude":
+		err = cmdClaude()
 	case "help", "--help", "-h":
 		fmt.Print(usage)
 	default:
@@ -289,4 +294,19 @@ decisions:
 	fmt.Printf("Created %s\n", filename)
 
 	return nil
+}
+
+func cmdClaude() error {
+	if len(os.Args) < 3 {
+		return errClaudeSubcommand
+	}
+
+	switch os.Args[2] {
+	case "enable":
+		return adapter.EnableClaude()
+	case "disable":
+		return adapter.DisableClaude()
+	default:
+		return errClaudeSubcommand
+	}
 }

--- a/internal/adapter/claude_setup.go
+++ b/internal/adapter/claude_setup.go
@@ -1,0 +1,284 @@
+package adapter
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const settingsFile = ".claude/settings.local.json"
+const hookCommand = "sctx hook"
+const hookMatcher = "Read|Write|Edit|MultiEdit"
+
+var (
+	errNoDotClaude = errors.New(".claude/ directory not found — run this from a Claude Code project")
+	errInvalidJSON = fmt.Errorf("%s contains invalid JSON", settingsFile)
+)
+
+// hookGroup is the structure for a single hook matcher group in Claude Code settings.
+type hookGroup struct {
+	Matcher string        `json:"matcher"`
+	Hooks   []hookHandler `json:"hooks"`
+}
+
+// hookHandler is a single hook handler entry.
+type hookHandler struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+// sctxHookGroup returns the hook group sctx needs registered.
+func sctxHookGroup() hookGroup {
+	return hookGroup{
+		Matcher: hookMatcher,
+		Hooks: []hookHandler{
+			{Type: "command", Command: hookCommand},
+		},
+	}
+}
+
+// EnableClaude adds sctx hooks to .claude/settings.local.json.
+func EnableClaude() error {
+	if err := requireDotClaude(); err != nil {
+		return err
+	}
+
+	settings, err := readSettings()
+	if err != nil {
+		return err
+	}
+
+	if hasSctxHooks(settings) {
+		fmt.Printf("sctx hooks are already enabled in %s\n", settingsFile)
+		return nil
+	}
+
+	addSctxHooks(settings)
+
+	if err := writeSettings(settings); err != nil {
+		return err
+	}
+
+	fmt.Printf("sctx hooks enabled in %s\n", settingsFile)
+
+	return nil
+}
+
+// DisableClaude removes sctx hooks from .claude/settings.local.json.
+func DisableClaude() error {
+	if err := requireDotClaude(); err != nil {
+		return err
+	}
+
+	settings, err := readSettings()
+	if err != nil {
+		return err
+	}
+
+	if !hasSctxHooks(settings) {
+		fmt.Printf("sctx hooks are not enabled in %s\n", settingsFile)
+		return nil
+	}
+
+	removeSctxHooks(settings)
+
+	if err := writeSettings(settings); err != nil {
+		return err
+	}
+
+	fmt.Printf("sctx hooks disabled in %s\n", settingsFile)
+
+	return nil
+}
+
+// requireDotClaude checks that the .claude/ directory exists.
+func requireDotClaude() error {
+	info, err := os.Stat(".claude")
+	if err != nil || !info.IsDir() {
+		return errNoDotClaude
+	}
+
+	return nil
+}
+
+// readSettings reads and parses the settings file, returning an empty map if the file doesn't exist.
+func readSettings() (map[string]any, error) {
+	data, err := os.ReadFile(settingsFile)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]any{}, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", settingsFile, err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, errInvalidJSON
+	}
+
+	return settings, nil
+}
+
+// writeSettings marshals and writes the settings map back to disk.
+func writeSettings(settings map[string]any) error {
+	dir := filepath.Dir(settingsFile)
+
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("creating %s: %w", dir, err)
+	}
+
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling settings: %w", err)
+	}
+
+	data = append(data, '\n')
+
+	return os.WriteFile(settingsFile, data, 0o600)
+}
+
+// hasSctxHooks checks whether any hook group in the settings contains the sctx hook command.
+func hasSctxHooks(settings map[string]any) bool {
+	hooks, ok := settings["hooks"]
+	if !ok {
+		return false
+	}
+
+	hooksMap, ok := hooks.(map[string]any)
+	if !ok {
+		return false
+	}
+
+	for _, event := range []string{"PreToolUse", "PostToolUse"} {
+		if eventHasSctxHook(hooksMap, event) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// eventHasSctxHook checks whether a specific event has an sctx hook.
+func eventHasSctxHook(hooksMap map[string]any, event string) bool {
+	groups, ok := hooksMap[event]
+	if !ok {
+		return false
+	}
+
+	groupList, ok := groups.([]any)
+	if !ok {
+		return false
+	}
+
+	for _, g := range groupList {
+		group, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if groupContainsSctxHook(group) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// groupContainsSctxHook checks whether a hook group contains the sctx hook command.
+func groupContainsSctxHook(group map[string]any) bool {
+	handlers, ok := group["hooks"]
+	if !ok {
+		return false
+	}
+
+	handlerList, ok := handlers.([]any)
+	if !ok {
+		return false
+	}
+
+	for _, h := range handlerList {
+		handler, ok := h.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if cmd, ok := handler["command"].(string); ok && cmd == hookCommand {
+			return true
+		}
+	}
+
+	return false
+}
+
+// addSctxHooks inserts the sctx hook groups into the settings map.
+func addSctxHooks(settings map[string]any) {
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		hooks = map[string]any{}
+		settings["hooks"] = hooks
+	}
+
+	group := sctxHookGroup()
+
+	// Convert to map[string]any so it serializes consistently with existing entries.
+	raw, err := json.Marshal(group)
+	if err != nil {
+		return
+	}
+
+	var groupMap map[string]any
+	if err := json.Unmarshal(raw, &groupMap); err != nil {
+		return
+	}
+
+	for _, event := range []string{"PreToolUse", "PostToolUse"} {
+		existing, ok := hooks[event].([]any)
+		if !ok {
+			existing = []any{}
+		}
+
+		hooks[event] = append(existing, groupMap)
+	}
+}
+
+// removeSctxHooks removes all hook groups containing the sctx hook command.
+func removeSctxHooks(settings map[string]any) {
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	for _, event := range []string{"PreToolUse", "PostToolUse"} {
+		groups, ok := hooks[event].([]any)
+		if !ok {
+			continue
+		}
+
+		var kept []any
+
+		for _, g := range groups {
+			group, ok := g.(map[string]any)
+			if !ok {
+				kept = append(kept, g)
+				continue
+			}
+
+			if !groupContainsSctxHook(group) {
+				kept = append(kept, g)
+			}
+		}
+
+		if len(kept) == 0 {
+			delete(hooks, event)
+		} else {
+			hooks[event] = kept
+		}
+	}
+
+	if len(hooks) == 0 {
+		delete(settings, "hooks")
+	}
+}

--- a/internal/adapter/claude_setup_test.go
+++ b/internal/adapter/claude_setup_test.go
@@ -1,0 +1,421 @@
+package adapter
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestEnableClaude(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T)
+		wantErr  string
+		wantFile bool
+		check    func(t *testing.T, settings map[string]any)
+	}{
+		{
+			name: "no .claude directory",
+			setup: func(t *testing.T) {
+				t.Helper()
+			},
+			wantErr: ".claude/ directory not found",
+		},
+		{
+			name: "creates settings file when missing",
+			setup: func(t *testing.T) {
+				t.Helper()
+				mkdirClaude(t)
+			},
+			wantFile: true,
+			check:    checkHooksPresent,
+		},
+		{
+			name: "adds hooks to empty settings",
+			setup: func(t *testing.T) {
+				t.Helper()
+				mkdirClaude(t)
+				writeTestSettings(t, map[string]any{})
+			},
+			wantFile: true,
+			check:    checkHooksPresent,
+		},
+		{
+			name: "preserves existing settings",
+			setup: func(t *testing.T) {
+				t.Helper()
+				mkdirClaude(t)
+				writeTestSettings(t, map[string]any{
+					"model": "claude-opus",
+				})
+			},
+			wantFile: true,
+			check: func(t *testing.T, s map[string]any) {
+				t.Helper()
+				checkHooksPresent(t, s)
+
+				if s["model"] != "claude-opus" {
+					t.Errorf("existing setting lost: got model=%v", s["model"])
+				}
+			},
+		},
+		{
+			name: "preserves existing hooks",
+			setup: func(t *testing.T) {
+				t.Helper()
+				mkdirClaude(t)
+				writeTestSettings(t, map[string]any{
+					"hooks": map[string]any{
+						"PreToolUse": []any{
+							map[string]any{
+								"matcher": "Bash",
+								"hooks": []any{
+									map[string]any{"type": "command", "command": "other-tool"},
+								},
+							},
+						},
+					},
+				})
+			},
+			wantFile: true,
+			check: func(t *testing.T, s map[string]any) {
+				t.Helper()
+				checkHooksPresent(t, s)
+
+				hooks, ok := s["hooks"].(map[string]any)
+				if !ok {
+					t.Fatal("missing hooks key")
+				}
+
+				pre, ok := hooks["PreToolUse"].([]any)
+				if !ok {
+					t.Fatal("missing PreToolUse key")
+				}
+
+				if len(pre) != 2 {
+					t.Errorf("expected 2 PreToolUse groups, got %d", len(pre))
+				}
+			},
+		},
+		{
+			name: "already enabled",
+			setup: func(t *testing.T) {
+				t.Helper()
+				mkdirClaude(t)
+				enabledSettings(t)
+			},
+			wantFile: true,
+			check:    checkHooksPresent,
+		},
+		{
+			name: "invalid JSON",
+			setup: func(t *testing.T) {
+				t.Helper()
+				mkdirClaude(t)
+
+				if err := os.WriteFile(settingsFile, []byte("{bad json"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: "invalid JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			tt.setup(t)
+
+			err := EnableClaude()
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantFile {
+				s := readSettingsFile(t)
+				tt.check(t, s)
+			}
+		})
+	}
+}
+
+func TestDisableClaude(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T)
+		wantErr string
+		check   func(t *testing.T, settings map[string]any)
+	}{
+		{
+			name: "no .claude directory",
+			setup: func(t *testing.T) {
+				t.Helper()
+			},
+			wantErr: ".claude/ directory not found",
+		},
+		{
+			name: "not enabled",
+			setup: func(t *testing.T) {
+				t.Helper()
+				mkdirClaude(t)
+				writeTestSettings(t, map[string]any{})
+			},
+			check: func(t *testing.T, s map[string]any) {
+				t.Helper()
+
+				if _, ok := s["hooks"]; ok {
+					t.Error("hooks key should not be present")
+				}
+			},
+		},
+		{
+			name: "removes sctx hooks",
+			setup: func(t *testing.T) {
+				t.Helper()
+				mkdirClaude(t)
+				enabledSettings(t)
+			},
+			check: func(t *testing.T, s map[string]any) {
+				t.Helper()
+
+				if _, ok := s["hooks"]; ok {
+					t.Error("hooks key should be removed when empty")
+				}
+			},
+		},
+		{
+			name: "preserves other hooks",
+			setup: func(t *testing.T) {
+				t.Helper()
+				mkdirClaude(t)
+				writeTestSettings(t, map[string]any{
+					"hooks": map[string]any{
+						"PreToolUse": []any{
+							map[string]any{
+								"matcher": "Bash",
+								"hooks": []any{
+									map[string]any{"type": "command", "command": "other-tool"},
+								},
+							},
+							map[string]any{
+								"matcher": hookMatcher,
+								"hooks": []any{
+									map[string]any{"type": "command", "command": hookCommand},
+								},
+							},
+						},
+						"PostToolUse": []any{
+							map[string]any{
+								"matcher": hookMatcher,
+								"hooks": []any{
+									map[string]any{"type": "command", "command": hookCommand},
+								},
+							},
+						},
+					},
+				})
+			},
+			check: func(t *testing.T, s map[string]any) {
+				t.Helper()
+
+				hooks, ok := s["hooks"].(map[string]any)
+				if !ok {
+					t.Fatal("missing hooks key")
+				}
+
+				pre, ok := hooks["PreToolUse"].([]any)
+				if !ok {
+					t.Fatal("missing PreToolUse key")
+				}
+
+				if len(pre) != 1 {
+					t.Errorf("expected 1 remaining PreToolUse group, got %d", len(pre))
+				}
+
+				if _, ok := hooks["PostToolUse"]; ok {
+					t.Error("PostToolUse should be removed when empty")
+				}
+			},
+		},
+		{
+			name: "preserves other settings",
+			setup: func(t *testing.T) {
+				t.Helper()
+				mkdirClaude(t)
+				writeTestSettings(t, map[string]any{
+					"model": "claude-opus",
+					"hooks": map[string]any{
+						"PreToolUse": []any{
+							map[string]any{
+								"matcher": hookMatcher,
+								"hooks": []any{
+									map[string]any{"type": "command", "command": hookCommand},
+								},
+							},
+						},
+						"PostToolUse": []any{
+							map[string]any{
+								"matcher": hookMatcher,
+								"hooks": []any{
+									map[string]any{"type": "command", "command": hookCommand},
+								},
+							},
+						},
+					},
+				})
+			},
+			check: func(t *testing.T, s map[string]any) {
+				t.Helper()
+
+				if s["model"] != "claude-opus" {
+					t.Errorf("existing setting lost: got model=%v", s["model"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			tt.setup(t)
+
+			err := DisableClaude()
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			s := readSettingsFile(t)
+			tt.check(t, s)
+		})
+	}
+}
+
+// helpers
+
+func mkdirClaude(t *testing.T) {
+	t.Helper()
+
+	if err := os.MkdirAll(".claude", 0o750); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeTestSettings(t *testing.T, v any) {
+	t.Helper()
+
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(".claude", 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(settingsFile, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readSettingsFile(t *testing.T) map[string]any {
+	t.Helper()
+
+	data, err := os.ReadFile(settingsFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+
+	return m
+}
+
+func enabledSettings(t *testing.T) {
+	t.Helper()
+
+	writeTestSettings(t, map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": hookMatcher,
+					"hooks": []any{
+						map[string]any{"type": "command", "command": hookCommand},
+					},
+				},
+			},
+			"PostToolUse": []any{
+				map[string]any{
+					"matcher": hookMatcher,
+					"hooks": []any{
+						map[string]any{"type": "command", "command": hookCommand},
+					},
+				},
+			},
+		},
+	})
+}
+
+func checkHooksPresent(t *testing.T, s map[string]any) {
+	t.Helper()
+
+	hooks, ok := s["hooks"].(map[string]any)
+	if !ok {
+		t.Fatal("missing hooks key")
+	}
+
+	for _, event := range []string{"PreToolUse", "PostToolUse"} {
+		groups, ok := hooks[event].([]any)
+		if !ok {
+			t.Fatalf("missing %s key", event)
+		}
+
+		found := false
+
+		for _, g := range groups {
+			group, ok := g.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			if groupContainsSctxHook(group) {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			t.Errorf("sctx hook not found in %s", event)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `sctx claude enable` and `sctx claude disable` commands
- These manage the sctx hook entries in `.claude/settings.local.json` so users don't have to manually copy-paste JSON

## Why

Right now, setting up sctx with Claude Code means copying a block of JSON from the README into your settings file. It's fiddly. Easy to get wrong. And if we ever change the hook config (new tool names, different matchers), everyone has to manually update their JSON.

A first-class command fixes that. `sctx claude enable` in your project directory and you're done.

## Approaches considered

We looked at three options:

**Direct JSON merge (single function)** - Just a standalone `Enable()` function that reads/writes the JSON file. Simple, but the merge logic would live outside the adapter package, disconnected from the hook definition it's supposed to match. If we ever add Cursor or Windsurf support, we'd end up duplicating the same pattern with no shared structure.

**Generic JSON patcher** - A declarative patching engine where adapters define their settings as data, and a generic patcher applies them. Cool in theory. Way too much machinery for one settings file and one agent. We'd be building a mini-framework with exactly one consumer.

**Adapter pattern (chosen)** - The hook definition and the setup logic live together in `internal/adapter/`, right next to the existing hook handler code. This means the hook config that gets written to settings.json is defined in the same package that actually processes those hooks. Single source of truth. If we add another agent later, it gets its own setup file in its own adapter package following the same pattern.

We went with the adapter approach because it matches the project's existing architecture without adding unnecessary abstraction. The cost over the "single function" approach is basically one extra file. The benefit over the generic patcher is we didn't spend a week building infrastructure we don't need.

## Behavior notes

"Already enabled" and "not enabled" are informational messages, not errors. Running `sctx claude enable` twice exits 0 both times. The commands preserve any existing settings and hooks in the file - they only touch the sctx-specific entries.