### PR TITLE
Add documentation website using MkDocs Material

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install -r docs/requirements.txt
+      - run: mkdocs gh-deploy --force --config-file docs/mkdocs.yml

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,10 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# MkDocs
+site/
+
+# Python
+.venv/
+.python-version

--- a/CONTEXT.yaml
+++ b/CONTEXT.yaml
@@ -76,3 +76,23 @@ decisions:
     rationale: "Tracking delivered context across a session adds state management complexity. Ship stateless first."
     revisit_when: "Users report redundant context being delivered"
     date: 2026-03-06
+
+  - decision: "MkDocs config and requirements live inside docs/, not project root"
+    rationale: "Keeps the root clean for Go developers who don't care about the docs site. All website config stays in one directory, which makes it easier to eventually split docs into its own repo."
+    alternatives:
+      - option: "mkdocs.yml and requirements at project root"
+        reason_rejected: "Standard MkDocs convention, but adds Python files to a Go project root. Confuses new contributors who see unfamiliar config files."
+    revisit_when: "Docs are moved to a separate repo"
+    date: 2026-03-07
+
+  - decision: "MkDocs Material over Hugo, Starlight, and Jekyll for the docs site"
+    rationale: "Best polish-to-effort ratio. Single pip install, docs/ works as content directory out of the box, no JS build toolchain. GoReleaser (similar Go CLI project) uses it too."
+    alternatives:
+      - option: "Hugo with hugo-book theme"
+        reason_rejected: "Native to Go ecosystem but doc themes are less polished. Go template language is painful for customization."
+      - option: "Starlight (Astro)"
+        reason_rejected: "Great output and near-zero client JS, but pre-1.0, wants content in src/content/docs/, and pulls in 400-600 npm packages."
+      - option: "Jekyll with just-the-docs"
+        reason_rejected: "Introduces Ruby/Bundler dependency. Jekyll development has slowed significantly."
+    revisit_when: "Docs are moved to a separate repo and we want to reconsider the stack"
+    date: 2026-03-07

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+sctx.dev

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,4 +1,9 @@
-# CLI Reference
+---
+title: CLI reference
+description: All sctx commands, flags, and exit codes
+---
+
+# CLI reference
 
 ## sctx hook
 
@@ -72,6 +77,22 @@ sctx init
 
 Refuses to overwrite an existing `CONTEXT.yaml`.
 
+## sctx claude enable
+
+Installs the `sctx hook` into your project's `.claude/settings.json`. Creates the file and directory if they don't exist. If hooks are already configured, it leaves them alone.
+
+```bash
+sctx claude enable
+```
+
+## sctx claude disable
+
+Removes the `sctx hook` entries from `.claude/settings.json`.
+
+```bash
+sctx claude disable
+```
+
 ## sctx version
 
 Prints the version.
@@ -84,5 +105,5 @@ sctx version
 
 | Code | Meaning |
 |---|---|
-| 0 | Success. This includes "no context matched" -- that's not an error. |
-| 1 | Fatal error (invalid arguments, IO failure, validation errors) |
+| 0 | Success (includes "no context matched" -- that's not an error) |
+| 1 | Fatal error: invalid arguments, IO failure, validation errors |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,3 +1,8 @@
+---
+title: Contributing
+description: How to build, test, and contribute to sctx
+---
+
 # Contributing
 
 ## Prerequisites

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,10 +1,15 @@
+---
+title: Examples
+description: Real-world patterns for using Structured Context in dbt, API, React, Terraform, and monorepo projects
+---
+
 # Examples
 
 Real-world patterns for using Structured Context. Each example shows the problem, the file structure, and the CONTEXT.yaml that solves it.
 
 ## dbt project
 
-A dbt `models/` directory contains SQL models, YAML schema files, and markdown documentation. An agent editing a SQL model needs completely different context than one editing a YAML schema.
+A dbt `models/` directory contains SQL models, YAML schema files, and markdown docs. An agent editing a SQL model needs completely different context than one editing a YAML schema.
 
 ```
 models/
@@ -67,7 +72,7 @@ decisions:
     match: ["**/*.sql"]
 ```
 
-With AGENTS.md, this entire block would be one file where every paragraph starts with "If you're editing a SQL file..." or "For YAML schema files...". The agent parses all of it every time, regardless of which file it's touching.
+With AGENTS.md, this entire block would be one file where every paragraph starts with "if you're editing a SQL file..." The agent parses all of it every time, regardless of which file it's touching.
 
 ## API service
 
@@ -304,7 +309,7 @@ decisions:
 
 When an agent edits `packages/payments/src/checkout.ts`, it gets the shared monorepo conventions *and* the payments-specific context. The payments context appears last, giving it stronger influence.
 
-## Best practices for decisions
+## Writing good decisions
 
 A good decision entry answers four questions:
 
@@ -336,4 +341,4 @@ decisions:
     date: 2025-05-15
 ```
 
-Dates matter too. A decision made two years ago under different constraints might be worth questioning. A decision made last week probably isn't.
+Dates matter too. A decision made two years ago under different constraints might be worth questioning. One made last week probably isn't.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,25 +1,30 @@
+---
+title: Getting started
+description: Install sctx and create your first context file
+---
+
 # Getting started
 
 ## Install
 
-### Homebrew (macOS or Linux)
+=== "Homebrew (macOS or Linux)"
 
-```bash
-brew install gregology/tap/sctx
-```
+    ```bash
+    brew install gregology/tap/sctx
+    ```
 
-### From source
+=== "From source"
 
-```bash
-go install github.com/gregology/sctx/cmd/sctx@latest
-```
+    ```bash
+    go install github.com/gregology/sctx/cmd/sctx@latest
+    ```
 
-Make sure `~/go/bin` is in your PATH:
+    Make sure `~/go/bin` is in your PATH:
 
-```bash
-echo 'export PATH="$PATH:$(go env GOPATH)/bin"' >> ~/.zshrc
-source ~/.zshrc
-```
+    ```bash
+    echo 'export PATH="$PATH:$(go env GOPATH)/bin"' >> ~/.zshrc
+    source ~/.zshrc
+    ```
 
 ## Create your first context file
 
@@ -91,6 +96,12 @@ Add this to `.claude/settings.json` in your project (or `~/.claude/settings.json
 }
 ```
 
+Or let sctx do it for you:
+
+```bash
+sctx claude enable
+```
+
 Now when Claude reads or edits a file, `sctx` automatically injects the relevant context. If nothing matches, it's a silent no-op.
 
 ## Add more context files
@@ -109,10 +120,10 @@ project/
     CONTEXT.yaml         <- testing standards
 ```
 
-Child directories inherit and merge with parent context. You don't need to repeat yourself.
+Child directories inherit and merge with parent context. No need to repeat yourself.
 
-## Next steps
+## What's next
 
-- [Examples](examples.md) for patterns in dbt, React, Terraform, and more
-- [Protocol spec](protocol.md) for the full schema reference
-- [CLI reference](cli-reference.md) for all commands and flags
+- [Examples](examples.md) -- patterns for dbt, React, Terraform, and more
+- [Protocol spec](protocol.md) -- the full schema reference
+- [CLI reference](cli-reference.md) -- all commands and flags

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,27 +1,27 @@
+---
+title: Structured Context
+description: Scoped, structured context for AI agents
+---
+
 # Structured Context
 
-Structured Context is a protocol for storing scoped, machine-readable context alongside your code. It gives AI agents the right guidance at the right time, for the right files.
+Drop `CONTEXT.yaml` files into your codebase and AI agents get the right guidance at the right time.
 
 ## The problem
 
-AI coding agents read instruction files like `AGENTS.md` to understand how to work in a codebase. These files are blunt instruments. They're scoped to a directory, they're unstructured prose, and every instruction in them gets loaded regardless of what the agent is actually doing.
+AI coding agents read instruction files like `AGENTS.md` to understand how to work in a codebase. These files are blunt instruments. They're scoped to a directory, written as unstructured paragraphs and code snippets, and every instruction gets loaded regardless of what the agent is actually doing.
 
-This falls apart fast.
+This approach bloats context.
 
-Consider a dbt project. A single `models/` directory contains SQL model files, YAML schema files, and markdown documentation files. The context an agent needs for each of these is completely different:
+Take a dbt project. A single `models/` directory contains SQL model files, YAML schema files, and markdown docs. The context an agent needs for each of these is completely different:
 
-- When editing a **SQL model**, the agent should know about your SQL style conventions, which macros are available, and that you use incremental models with a specific strategy.
-- When editing a **YAML schema**, it should know your testing conventions, required fields for every model, and how you structure column descriptions.
-- When editing a **markdown doc**, it should know your documentation template and that business stakeholders read these files.
+- When editing a **SQL model**, the agent should know about your SQL style, deprecated functions, available macros, and incremental strategy.
+- When editing a **YAML schema**, it should know your testing conventions, required fields, and how you structure column descriptions.
+- When editing a **markdown doc**, it should know your documentation templates and style.
 
-With `AGENTS.md`, your only option is one big file that says "if you're editing SQL do X, if you're editing YAML do Y, if you're editing markdown do Z." That's conditional logic written as prose. The agent has to parse natural language to figure out which instructions apply. That's wasteful and error-prone.
+With `AGENTS.md`, your only option is one big file where every paragraph starts with "if you're editing SQL do X, if you're editing YAML do Y." That's conditional logic written as prose. The agent has to parse natural language to figure out which instructions apply. Wasteful and error-prone.
 
-This pattern shows up everywhere:
-
-- **API directories** with route handlers, middleware, tests, and OpenAPI specs
-- **React component directories** with `.tsx`, `.test.tsx`, `.stories.tsx`, and `.module.css` files
-- **Infrastructure directories** with Terraform `.tf` files, `.tfvars`, and documentation
-- **Monorepo packages** where shared conventions apply globally but each package has its own patterns
+This pattern shows up everywhere. API directories with route handlers, middleware, tests, and OpenAPI specs. React component directories with `.tsx`, `.test.tsx`, `.stories.tsx`, and `.module.css` files. Infrastructure directories with Terraform `.tf` files, `.tfvars`, and documentation. Monorepo packages where shared conventions apply globally but each package has its own patterns.
 
 The underlying issue: files in the same directory often have very different context requirements. Directory-scoped unstructured text can't express this.
 
@@ -38,25 +38,23 @@ Context files are placed throughout your codebase and merge with parent director
 
 The protocol is agent-agnostic. The reference implementation (`sctx`) ships with a Claude Code adapter, but the core engine has no knowledge of any specific agent. Other tools can adopt the file format directly.
 
-Context entries and decisions are queried separately. `sctx context` returns actionable guidance for a file. `sctx decisions` returns the architectural decisions that apply. The hook integration (`sctx hook`) only sends context entries to the agent, keeping token costs low. Decisions are there for humans and for agents that explicitly ask.
-
 ## Why this matters beyond better output
 
-The obvious benefit is accuracy -- agents follow your conventions instead of guessing. But precise context has compounding effects:
+The obvious benefit is better output. Agents follow your conventions instead of guessing or being saturated with irrelevant context to the specific task. Precise context has compounding effects.
 
-**Smaller models become viable.** A large model can sometimes infer the right pattern from a sprawling AGENTS.md. A smaller model can't. But give a small model exactly the right context for the file it's touching, and it performs surprisingly well. Structured Context closes the gap between model tiers by compensating with better input.
+**Smaller models become viable.** A large model can sometimes infer the right pattern from a sprawling AGENTS.md. A smaller model may struggle. But a small model with exactly the right context can perform well. Structured Context closes the gap between model tiers by compensating with better input.
 
-**Costs drop.** Less irrelevant context means fewer input tokens. If your AGENTS.md is 2,000 tokens but only 200 are relevant to the current file, you're paying for 1,800 tokens of noise on every tool call. Multiply that across a session with hundreds of file operations.
+**Costs drop.** There's the obvious part: less context per call means fewer input tokens. But the bigger win is iteration count. When an agent has the right guidance every time it touches a file, it makes fewer mistakes and needs fewer fix-up cycles. A wrong assumption in call 5 can mean 30 wasted calls cleaning it up.
 
 **Responses get faster.** Fewer input tokens means lower latency. For agents in the hot loop of an edit-test cycle, shaving tokens off every call adds up.
 
 **Accuracy improves.** LLMs degrade when context is long and diluted. Giving the model 5 focused sentences instead of 50 scattered paragraphs means it's more likely to actually follow the instructions. The signal-to-noise ratio of your prompt directly affects output quality.
 
-## Next steps
+## Quick start
 
-- [Getting started](getting-started.md) -- install `sctx` and create your first context file
-- [Protocol specification](protocol.md) -- the full spec for implementors
-- [Examples](examples.md) -- real-world patterns for common project types
-- [CLI reference](cli-reference.md) -- `sctx` commands and flags
-- [Contributing](contributing.md) -- how to work on the project
-- [Roadmap](roadmap.md) -- what's planned
+```bash
+brew install gregology/tap/sctx
+sctx init
+```
+
+Then [hook it into Claude Code](getting-started.md#hook-into-claude-code) and you're done.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,70 @@
+site_name: Structured Context
+site_url: https://sctx.dev
+site_description: Scoped, structured context for AI agents. Drop CONTEXT.yaml files into your codebase and agents get the right guidance at the right time.
+docs_dir: .
+site_dir: ../site
+repo_url: https://github.com/gregology/sctx
+repo_name: gregology/sctx
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.snippets
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+  - tables
+  - def_list
+  - pymdownx.tasklist:
+      custom_checkbox: true
+
+nav:
+  - Home: index.md
+  - Getting started: getting-started.md
+  - Protocol: protocol.md
+  - Examples: examples.md
+  - CLI reference: cli-reference.md
+  - Contributing: contributing.md
+  - Roadmap: roadmap.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/gregology/sctx

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,6 +1,11 @@
-# Protocol Specification
+---
+title: Protocol specification
+description: The full Structured Context file format, schema, resolution algorithm, and merge behavior
+---
 
-This document defines the Structured Context protocol: the file format, schema, resolution algorithm, and merge behavior. It's intended for implementors building tools that read or write context files.
+# Protocol specification
+
+This defines the Structured Context protocol: the file format, schema, resolution algorithm, and merge behavior. It's written for implementors building tools that read or write context files.
 
 ## Context files
 
@@ -13,7 +18,7 @@ This document defines the Structured Context protocol: the file format, schema, 
 | `AGENTS.yaml` | Recognized for compatibility with the AGENTS.md convention |
 | `AGENTS.yml` | Alternate extension |
 
-Both `.yaml` and `.yml` are common YAML conventions. The protocol accepts both.
+Both `.yaml` and `.yml` are standard. The protocol accepts both.
 
 If multiple context files exist in the same directory, all are loaded and their contents merged. This lets teams split context across files or use whichever naming convention they prefer.
 
@@ -72,7 +77,7 @@ A self-contained, actionable piece of guidance. Prefer multiple focused entries 
 
 #### `match` and `exclude`
 
-Standard glob patterns. The same syntax used in `.gitignore`, `.editorconfig`, and similar tools.
+Standard glob patterns. Same syntax as `.gitignore`, `.editorconfig`, and similar tools.
 
 Globs are resolved relative to the directory containing the context file, not the project root. A pattern `**/*.py` in `src/api/CONTEXT.yaml` matches Python files under `src/api/`, not the entire project.
 
@@ -158,7 +163,7 @@ Given a file path, an action, and a timing:
 4. **Filter by action** -- Keep entries where `on` includes the requested action (or is `all`)
 5. **Filter by timing** -- Keep entries where `when` matches the requested timing
 6. **Merge** -- Combine all matching entries. Parent directory entries come first, child directory entries come last
-7. **Return** -- The ordered list of matching context entries and decisions. Callers choose which to use: `sctx hook` returns only context entries, `sctx context` returns only context entries, `sctx decisions` returns only decisions
+7. **Return** -- The ordered list of matching context entries and decisions
 
 ### Merge order
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material==9.6.7

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,3 +1,8 @@
+---
+title: Roadmap
+description: What's shipped, what's planned, and what's on the horizon
+---
+
 # Roadmap
 
 ## v1 (current)
@@ -27,7 +32,6 @@ Richer context management and broader agent support.
 - [ ] **Temporal filtering** -- context that activates after a date or expires before a date, for migration periods and deprecation windows
 - [ ] **Extensible filtering** -- framework for community-requested filter dimensions beyond glob, action, timing, and date
 
-
 ## v3 (future)
 
 Advanced features for teams and organizations.
@@ -35,4 +39,4 @@ Advanced features for teams and organizations.
 - [ ] **Remote context sources** -- URL-based context that accepts parameters, for centralized guidelines or dynamic context
 - [ ] **Context versioning** -- track when entries were last updated, surface stale context
 - [ ] **Analytics** -- which context entries are delivered most and least, helping teams identify gaps and noise
-- [ ] **Context benchmarking** -- A/B test different context entries to measure which produce better agent outcomes in specific situations
+- [ ] **Context benchmarking** -- A/B test different context entries to measure which produce better agent outcomes


### PR DESCRIPTION
## Why

We have good docs in `docs/` but they only render on GitHub. A proper website at `sctx.dev` makes the project look real, gives us search, dark mode, syntax-highlighted code blocks, and a nav structure that doesn't require people to click around a GitHub repo.

## Approach: MkDocs Material

Looked at four options:

- **MkDocs Material** (Python) -- single pip install, `docs/` is the default content directory so our existing markdown files work as-is, massive community, used by GoReleaser which is basically the same kind of project as ours
- **Hugo + hugo-book** (Go) -- native to the Go ecosystem which is nice, but the doc themes are less polished out of the box and the Go template language is painful if you ever need to customize anything
- **Starlight / Astro** (Node) -- great output, near-zero client JS, built-in Pagefind search. But it's pre-1.0, wants content in `src/content/docs/` instead of `docs/`, and pulls in 400-600 npm packages for what is fundamentally a static markdown site
- **Jekyll + just-the-docs** (Ruby) -- mature and GitHub's own `gh` CLI uses it, but introduces Ruby/Bundler as a dependency. Jekyll's development has also slowed down a lot

MkDocs Material won on the polish-to-effort ratio. The config is ~60 lines of YAML. The GitHub Actions workflow is ~20 lines. Our existing docs needed only front matter additions and minor rewrites to work. No JS build toolchain, no node_modules, no Ruby gems. Just `pip install mkdocs-material` in CI.

## What's in here

- `mkdocs.yml` -- site config with Material theme, light/dark toggle, code copy buttons, instant navigation, search
- `requirements-docs.txt` -- pins mkdocs-material version
- `.github/workflows/docs.yml` -- builds and deploys to `gh-pages` branch on push to main (only triggers when docs or config change)
- `docs/CNAME` -- tells GitHub Pages to serve from `sctx.dev`
- Doc rewrites -- added front matter to all pages, added tabbed install instructions in getting-started, documented `sctx claude enable/disable` in the CLI reference, tightened up prose on the index page

## To go live after merge

1. In repo Settings -> Pages, set source to "Deploy from a branch" and pick `gh-pages`
2. Configure DNS for `sctx.dev` -- CNAME to `gregology.github.io` or A records to GitHub Pages IPs
3. Wait for the first workflow run to complete