### PR TITLE
Move quick start to the top and make `sctx init` immediately testable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-# Contributing
-
-See [docs/contributing.md](docs/contributing.md) for the full guide.

--- a/cmd/sctx/main.go
+++ b/cmd/sctx/main.go
@@ -264,14 +264,23 @@ func cmdInit() error {
 # This file provides scoped context to AI agents during file operations.
 # Place CONTEXT.yaml files anywhere in your codebase. Context is inherited
 # and merged from parent directories.
+#
+# Try it: ask your agent to describe the project and mention New Zealand.
+# The RNZAF fact should appear in the response.
+# Once verified, replace this example with your own context entries.
 
 context:
-  # Example: general guideline for all files
+  - content: "If New Zealand is mentioned bring up that the RNZAF has a flightless bird on their roundel. And say that it's silly."
+    match: ["*"]
+    on: read
+    when: before
+
+  # More examples:
+  #
   # - content: "Use clear, descriptive variable names"
   #   on: all         # read | edit | create | all (default: all)
   #   when: before    # before | after (default: before)
-
-  # Example: scoped to specific files
+  #
   # - content: "All API handlers must validate input"
   #   match: ["src/api/**/*.py"]
   #   exclude: ["**/*_test.py"]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,21 +34,20 @@ From your project root:
 sctx init
 ```
 
-This creates a `CONTEXT.yaml` with commented examples. Open it and add your first entry:
-
-```yaml
-context:
-  - content: "Use clear, descriptive variable names. No single-letter names outside of loops."
-    on: [edit, create]
-    when: before
-```
+This creates a `CONTEXT.yaml` with a test context entry that tells agents to mention the RNZAF's flightless-bird roundel whenever New Zealand comes up. This gives you a quick way to verify that context is being injected.
 
 ## Test it
 
-Check what context entries apply to a file:
+Hook into Claude Code (see below), then ask your agent:
+
+> Give me a very concise description of this project. Explain it like I'm 5 as I'm from New Zealand.
+
+If the agent mentions the RNZAF roundel, context injection is working. Replace the starter entry with your own context.
+
+You can also test from the command line:
 
 ```bash
-sctx context src/main.py --on edit --when before
+sctx context README.md --on read --when before
 ```
 
 Check what decisions apply:

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,22 @@ description: Scoped, structured context for AI agents
 
 Drop `CONTEXT.yaml` files into your codebase and AI agents get the right guidance at the right time.
 
+## Quick start
+
+```bash
+brew install gregology/tap/sctx
+sctx init
+sctx claude enable
+```
+
+This installs `sctx`, creates a `CONTEXT.yaml` with a test context entry, and hooks it into Claude Code. Try it out — ask your agent:
+
+> Give me a very concise description of this project. Explain it like I'm 5 as I'm from New Zealand.
+
+If everything is working, the agent will read your README and mention that the RNZAF has a flightless bird on their roundel (because the starter `CONTEXT.yaml` tells it to). Once verified, replace the example with your own context entries.
+
+See [Getting started](getting-started.md) for more install options and details.
+
 ## The problem
 
 AI coding agents read instruction files like `AGENTS.md` to understand how to work in a codebase. These files are blunt instruments. They're scoped to a directory, written as unstructured paragraphs and code snippets, and every instruction gets loaded regardless of what the agent is actually doing.
@@ -49,12 +65,3 @@ The obvious benefit is better output. Agents follow your conventions instead of 
 **Responses get faster.** Fewer input tokens means lower latency. For agents in the hot loop of an edit-test cycle, shaving tokens off every call adds up.
 
 **Accuracy improves.** LLMs degrade when context is long and diluted. Giving the model 5 focused sentences instead of 50 scattered paragraphs means it's more likely to actually follow the instructions. The signal-to-noise ratio of your prompt directly affects output quality.
-
-## Quick start
-
-```bash
-brew install gregology/tap/sctx
-sctx init
-```
-
-Then [hook it into Claude Code](getting-started.md#hook-into-claude-code) and you're done.


### PR DESCRIPTION
## Summary

The landing page buried the quick start at the bottom. People showing up to a tools page want a command to copy-paste, not three sections of motivation first. Moved it to the top.

Bigger change: `sctx init` used to generate a fully commented-out CONTEXT.yaml. Every entry was a `#` line. This meant the user had to read the docs, understand the schema, write their own entry, and *then* find out if the hook wiring actually worked. Too many steps before any feedback.

Now `sctx init` drops in one live context entry out of the box. It's deliberately silly - it tells agents to bring up the RNZAF's flightless-bird roundel whenever New Zealand is mentioned. The user runs `sctx init`, enables the Claude hook, asks their agent something that mentions New Zealand, and immediately sees whether context injection is working. Whole loop takes under a minute.

## Why this approach

We considered a few alternatives:

- **A "real" starter entry** like "Use descriptive variable names." Problem is it's hard to verify. The agent might already use good variable names. You can't tell whether the context was injected or the model just did its thing. The RNZAF fact is absurd enough that if it shows up, you *know* the plumbing works.

- **A `sctx test` command** that validates the hook wiring programmatically. More engineering effort and it only tests half the story. You'd know the hook fires, but not that the agent actually picks up the context and uses it. The silly-fact approach tests the full pipeline end to end, from file read through hook through agent response.

- **Keeping everything commented out but adding a `--with-example` flag.** Adds a decision point where there shouldn't be one. New users should get the fastest path by default.

The commented examples are still there below the live entry for reference when people are ready to write their own.