### PR TITLE
Reframe docs to lead with value and position alongside AGENTS.md

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -56,7 +56,7 @@ sctx decisions src/api/handler.py --json
 
 ## sctx validate [\<dir\>]
 
-Validates all `AGENTS.yaml` and `AGENTS.yaml` files found in a directory tree. Reports schema errors and invalid glob patterns.
+Validates all `AGENTS.yaml` and `AGENTS.yml` files found in a directory tree. Reports schema errors and invalid glob patterns.
 
 ```bash
 sctx validate

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -72,7 +72,7 @@ decisions:
     match: ["**/*.sql"]
 ```
 
-With AGENTS.md, this entire block would be one file where every paragraph starts with "if you're editing a SQL file..." The agent parses all of it every time, regardless of which file it's touching.
+You could put all of this in an `AGENTS.md`, but every paragraph would start with "if you're editing a SQL file..." and the agent would parse all of it every time. With `AGENTS.yaml`, each entry is scoped to exactly the files it applies to.
 
 ## API service
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,13 @@
 ---
 title: Structured Context
-description: Scoped, structured context for AI agents
+description: Give AI agents the right context at the right time
 ---
 
 # Structured Context
 
-Drop `AGENTS.yaml` files into your codebase and AI agents get the right guidance at the right time.
+AI coding agents work better when they get focused, relevant context. But instruction files are broad by design, and LLMs lose track of what matters as context grows. The result is wasted cycles: wrong patterns applied, conventions broken, more calls spent fixing the damage.
+
+Structured Context gives you fine-grained control over what an agent sees and when. Drop `AGENTS.yaml` files into your codebase and the right guidance shows up for the right files, filtered by what the agent is actually doing.
 
 ## Quick start
 
@@ -27,21 +29,15 @@ See [Getting started](getting-started.md) for more install options and details.
 
 ## The problem
 
-AI coding agents read instruction files like `AGENTS.md` to understand how to work in a codebase. These files are blunt instruments. They're scoped to a directory, written as unstructured paragraphs and code snippets, and every instruction gets loaded regardless of what the agent is actually doing.
+Instruction files like `AGENTS.md` and `CLAUDE.md` are good for project-wide guidance. But they're directory-scoped and unstructured, so every instruction gets loaded regardless of what the agent is actually doing. As they grow, LLMs start losing signal in the noise. Recency bias kicks in, attention dilutes, and the model quietly ignores the instruction that mattered most.
 
-This approach bloats context.
+The real gap is granularity. Files in the same directory often need completely different context.
 
-Take a dbt project. A single `models/` directory contains SQL model files, YAML schema files, and markdown docs. The context an agent needs for each of these is completely different:
+Take a dbt project. A single `models/` directory contains SQL model files, YAML schema files, and markdown docs. When an agent edits a SQL model, it should know about your SQL style, available macros, and incremental strategy. When it edits a YAML schema, it needs your testing conventions and required fields. Markdown docs need your documentation templates.
 
-- When editing a **SQL model**, the agent should know about your SQL style, deprecated functions, available macros, and incremental strategy.
-- When editing a **YAML schema**, it should know your testing conventions, required fields, and how you structure column descriptions.
-- When editing a **markdown doc**, it should know your documentation templates and style.
+You can put all of this in one `AGENTS.md` where every paragraph starts with "if you're editing SQL do X, if you're editing YAML do Y." That works, but it's conditional logic written as prose. The agent has to parse natural language to figure out which instructions apply, and as the file gets longer it increasingly won't.
 
-With `AGENTS.md`, your only option is one big file where every paragraph starts with "if you're editing SQL do X, if you're editing YAML do Y." That's conditional logic written as prose. The agent has to parse natural language to figure out which instructions apply. Wasteful and error-prone.
-
-This pattern shows up everywhere. API directories with route handlers, middleware, tests, and OpenAPI specs. React component directories with `.tsx`, `.test.tsx`, `.stories.tsx`, and `.module.css` files. Infrastructure directories with Terraform `.tf` files, `.tfvars`, and documentation. Monorepo packages where shared conventions apply globally but each package has its own patterns.
-
-The underlying issue: files in the same directory often have very different context requirements. Directory-scoped unstructured text can't express this.
+This pattern shows up everywhere. API directories with route handlers, middleware, and OpenAPI specs. React component directories with `.tsx`, `.test.tsx`, `.stories.tsx`, and `.module.css` files. Monorepo packages where shared conventions apply globally but each package has its own patterns.
 
 ## The approach
 
@@ -56,14 +52,14 @@ Context files are placed throughout your codebase and merge with parent director
 
 The protocol is agent-agnostic. The reference implementation (`sctx`) ships with a Claude Code adapter, but the core engine has no knowledge of any specific agent. Other tools can adopt the file format directly.
 
-## Why this matters beyond better output
+## Why this matters
 
-The obvious benefit is better output. Agents follow your conventions instead of guessing or being saturated with irrelevant context to the specific task. Precise context has compounding effects.
+Precise context compounds.
 
-**Smaller models become viable.** A large model can sometimes infer the right pattern from a sprawling AGENTS.md. A smaller model may struggle. But a small model with exactly the right context can perform well. Structured Context closes the gap between model tiers by compensating with better input.
+**Smaller models become viable.** A large model can sometimes power through a long instruction file. A smaller model can't. It gets lost, introduces anti-patterns, burns cycles reverting its own mistakes. But a small model with exactly the right context can match a large model running on vague context. Better input closes the gap between model tiers.
 
-**Costs drop.** There's the obvious part: less context per call means fewer input tokens. But the bigger win is iteration count. When an agent has the right guidance every time it touches a file, it makes fewer mistakes and needs fewer fix-up cycles. A wrong assumption in call 5 can mean 30 wasted calls cleaning it up.
+**Costs drop.** Fewer input tokens is the obvious part. The bigger win is iteration count. When an agent has the right guidance every time it touches a file, it makes fewer mistakes and needs fewer fix-up cycles. A wrong assumption in call 5 can mean 30 wasted calls cleaning it up. Tasks that used to stall, with the agent breaking things faster than it fixed them, can start completing.
 
 **Responses get faster.** Fewer input tokens means lower latency. For agents in the hot loop of an edit-test cycle, shaving tokens off every call adds up.
 
-**Accuracy improves.** LLMs degrade when context is long and diluted. Giving the model 5 focused sentences instead of 50 scattered paragraphs means it's more likely to actually follow the instructions. The signal-to-noise ratio of your prompt directly affects output quality.
+**Accuracy improves.** LLMs degrade when context is long and diluted. Five focused sentences beat fifty scattered paragraphs. The signal-to-noise ratio of your prompt directly affects output quality.


### PR DESCRIPTION
## Summary

The landing page wasn't communicating the value of this tool fast enough. Someone hitting index.md had to read through "the problem" and "the approach" before understanding why they should care. The intro was mechanism-first ("drop AGENTS.yaml files") instead of outcome-first.

The other issue was tone. The docs read like sctx was gunning to replace AGENTS.md. That's not what this is. AGENTS.md and CLAUDE.md are good for project-wide guidance. sctx fills a different gap: per-file granularity, action filtering, and prompt positioning. They work together.

## What changed and why

**Reframed the intro** to lead with the problem (agents waste cycles when context is unfocused) before explaining the mechanism. Considered two approaches here:

- *Pure value-prop opener* ("Make your AI agents 10x more efficient") - too marketing-y for this project's voice. Felt dishonest.
- *Problem-first opener* (what goes wrong without targeted context, then how sctx fixes it) - this is what we went with. It matches the rest of the docs which are direct and technical.

**Repositioned relative to AGENTS.md.** The old copy called instruction files "blunt instruments" and framed AGENTS.md as the thing you're escaping from. Now it acknowledges they're good for what they do, and identifies granularity as the real gap. This matters because most people landing on these docs already use AGENTS.md and we don't want them feeling defensive about it.

Considered keeping the confrontational framing since it's punchier. Decided against it because it's also wrong. You'd still want an AGENTS.md for broad project conventions even if you adopt sctx for file-level context.

**Added LLM recency bias to the problem statement.** The old version blamed "bloated context" as if the only issue was token count. The deeper issue is that LLMs degrade on long, diluted context due to attention patterns and recency bias. This is a stronger argument for the tool because it means the problem gets worse as instruction files grow, not just more expensive.

**Cleaned up "Why this matters" section.** Removed some filler, tightened the smaller-models pitch, added a line about previously-stalling tasks becoming completable. Reduced dash usage throughout since heavy em-dash use is an LLM writing tell.

**Fixed typo in cli-reference.md** where `AGENTS.yml` was written as `AGENTS.yaml` twice.