### PR TITLE
Fix ActionAll and TimingAll to match all entries instead of only literal "all"

### DIFF
--- a/cmd/sctx/main.go
+++ b/cmd/sctx/main.go
@@ -95,7 +95,7 @@ func cmdContext() error {
 
 	filePath := os.Args[2]
 	action := core.ActionAll
-	timing := core.TimingBefore
+	timing := core.TimingAll
 	jsonOutput := false
 
 	for i := 3; i < len(os.Args); i++ {
@@ -120,7 +120,7 @@ func cmdContext() error {
 			i++
 
 			if !core.ValidTiming(os.Args[i]) {
-				return fmt.Errorf("%w %q (must be before or after)", errInvalidTiming, os.Args[i])
+				return fmt.Errorf("%w %q (must be before, after, or all)", errInvalidTiming, os.Args[i])
 			}
 
 			timing = core.Timing(os.Args[i])

--- a/internal/adapter/claude_test.go
+++ b/internal/adapter/claude_test.go
@@ -298,8 +298,8 @@ context:
 		t.Errorf("expected all-action context for unknown tool, got: %s", ctx)
 	}
 
-	if strings.Contains(ctx, "Context for edits only") {
-		t.Errorf("should not contain edit-only context for unknown tool, got: %s", ctx)
+	if !strings.Contains(ctx, "Context for edits only") {
+		t.Errorf("unknown tool should see all context including edit-only, got: %s", ctx)
 	}
 }
 

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -151,7 +151,7 @@ func filterContext(cf ContextFile, absPath string, action Action, timing Timing)
 			continue
 		}
 
-		if Timing(entry.When) != timing {
+		if timing != TimingAll && Timing(entry.When) != timing {
 			continue
 		}
 
@@ -229,6 +229,10 @@ func matchesGlobs(sourceDir, absPath string, match, exclude []string) bool {
 
 // matchesAction checks if the requested action is included in the entry's on list.
 func matchesAction(on FlexList, action Action) bool {
+	if action == ActionAll {
+		return true
+	}
+
 	for _, a := range on {
 		if Action(a) == ActionAll || Action(a) == action {
 			return true

--- a/internal/core/engine_test.go
+++ b/internal/core/engine_test.go
@@ -114,6 +114,10 @@ func TestMatchesAction(t *testing.T) {
 		{"edit does not match read", FlexList{"edit"}, ActionRead, false},
 		{"multi-value list matches", FlexList{"edit", "create"}, ActionCreate, true},
 		{"multi-value list rejects", FlexList{"edit", "create"}, ActionRead, false},
+		{"requested all matches entry with on:edit", FlexList{"edit"}, ActionAll, true},
+		{"requested all matches entry with on:create", FlexList{"create"}, ActionAll, true},
+		{"requested all matches entry with on:read", FlexList{"read"}, ActionAll, true},
+		{"requested all matches entry with on:[edit,create]", FlexList{"edit", "create"}, ActionAll, true},
 	}
 
 	for _, tt := range tests {
@@ -333,6 +337,115 @@ func TestResolve_NoContextFiles(t *testing.T) {
 	}
 }
 
+func TestResolve_AllActionAllTimingReturnsEverything(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
+	writeTestFile(t, filepath.Join(tmpDir, "AGENTS.yaml"), `
+context:
+  - content: "before-all"
+    on: all
+    when: before
+  - content: "after-edit"
+    on: edit
+    when: after
+  - content: "before-create"
+    on: create
+    when: before
+  - content: "after-read"
+    on: read
+    when: after
+`)
+
+	target := filepath.Join(tmpDir, "file.go")
+	writeTestFile(t, target, "")
+
+	result, _, err := Resolve(ResolveRequest{
+		FilePath: target,
+		Action:   ActionAll,
+		Timing:   TimingAll,
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+
+	assertContextContents(t, result.ContextEntries, []string{
+		"before-all",
+		"after-edit",
+		"before-create",
+		"after-read",
+	})
+}
+
+func TestResolve_AllActionSpecificTiming(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
+	writeTestFile(t, filepath.Join(tmpDir, "AGENTS.yaml"), `
+context:
+  - content: "before-all"
+    on: all
+    when: before
+  - content: "after-edit"
+    on: edit
+    when: after
+  - content: "before-create"
+    on: create
+    when: before
+`)
+
+	target := filepath.Join(tmpDir, "file.go")
+	writeTestFile(t, target, "")
+
+	// ActionAll + TimingBefore should return all actions but only before timing.
+	result, _, err := Resolve(ResolveRequest{
+		FilePath: target,
+		Action:   ActionAll,
+		Timing:   TimingBefore,
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+
+	assertContextContents(t, result.ContextEntries, []string{
+		"before-all",
+		"before-create",
+	})
+}
+
+func TestResolve_SpecificActionAllTiming(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
+	writeTestFile(t, filepath.Join(tmpDir, "AGENTS.yaml"), `
+context:
+  - content: "before-all"
+    on: all
+    when: before
+  - content: "after-edit"
+    on: edit
+    when: after
+  - content: "before-create"
+    on: create
+    when: before
+`)
+
+	target := filepath.Join(tmpDir, "file.go")
+	writeTestFile(t, target, "")
+
+	// ActionEdit + TimingAll should return edit-matching entries for all timings.
+	result, _, err := Resolve(ResolveRequest{
+		FilePath: target,
+		Action:   ActionEdit,
+		Timing:   TimingAll,
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+
+	assertContextContents(t, result.ContextEntries, []string{
+		"before-all",
+		"after-edit",
+	})
+}
+
 // writeTestFile is a helper that writes a file and fails the test on error.
 func writeTestFile(t *testing.T, path, content string) {
 	t.Helper()
@@ -375,7 +488,7 @@ func genAction(t *rapid.T) Action {
 
 // genTiming generates a random valid Timing.
 func genTiming(t *rapid.T) Timing {
-	return rapid.SampledFrom([]Timing{TimingBefore, TimingAfter}).Draw(t, "timing")
+	return rapid.SampledFrom([]Timing{TimingBefore, TimingAfter, TimingAll}).Draw(t, "timing")
 }
 
 // genDirName generates a short directory name safe for filesystem use.

--- a/internal/core/schema.go
+++ b/internal/core/schema.go
@@ -73,6 +73,7 @@ type Timing string
 const (
 	TimingBefore Timing = "before"
 	TimingAfter  Timing = "after"
+	TimingAll    Timing = "all"
 )
 
 // ResolveRequest contains the universal inputs for context resolution.
@@ -101,7 +102,7 @@ func ValidAction(s string) bool {
 // ValidTiming reports whether s is a recognized timing value.
 func ValidTiming(s string) bool {
 	switch Timing(s) {
-	case TimingBefore, TimingAfter:
+	case TimingBefore, TimingAfter, TimingAll:
 		return true
 	}
 	return false


### PR DESCRIPTION
`sctx context <path>` was silently dropping entries. If you had an entry with `on: [edit, create]` and queried with the default action (which is `all`), it wouldn't show up. Same deal with `when: after` entries being invisible because the default timing was hardcoded to `before`.

The root cause was in two spots:

`matchesAction` checked whether the *entry's* `on` field was `all`, but never checked whether the *requested* action was `all`. So querying with action=all only matched entries literally tagged `on: all`, not "give me everything."

There was no `TimingAll` concept at all. The CLI defaulted to `TimingBefore`, so `when: after` entries were just gone from the output with no indication anything was missing.

### Why this approach

The obvious alternative was to make the CLI layer handle the "no flags means show everything" logic, maybe by running two queries (one for `before`, one for `after`) and merging results. But that pushes filtering semantics into the CLI when it belongs in the core engine. Every adapter would need to reimplement the same workaround.

Another option was to remove `all` as a queryable value entirely and instead have callers omit the field or pass a nil/zero value to mean "don't filter." This would mean changing `ResolveRequest` to use pointer types or a separate `FilterAction *Action` field. Felt like overcomplicating the API for something that should just work: `all` means all.

The fix we went with keeps the existing API shape. `ActionAll` as a requested action now means "match everything regardless of the entry's `on` value." `TimingAll` works the same way for the `when` dimension. The core engine owns all the filtering logic, adapters stay thin.

## Test plan

- [ ] `go run ./cmd/sctx context internal/validator/doc.go` returns all 4 matching root entries (previously returned 2)
- [ ] `sctx context <path> --on edit --when before` still filters correctly
- [ ] `make check` passes
