### PR TITLE
Use working directory as project root instead of marker-based detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ sctx decisions src/api/handler.py
 
 ## How it works
 
-`sctx` walks up the directory tree from the target file, collecting `AGENTS.yaml` files along the way. It filters entries by glob pattern, action type, and timing, then returns the matching context.
+`sctx` walks up the directory tree from the target file to the project root, collecting `AGENTS.yaml` files along the way. It filters entries by glob pattern, action type, and timing, then returns the matching context.
+
+The project root is the working directory — the directory where the tool was launched. In hook mode, this is the `cwd` from the agent's input (e.g. where `claude` was started). In CLI mode, it's where you run `sctx`. Only `AGENTS.yaml` files at or below the root are considered.
 
 Parent directory context merges with child directory context. Entries from parent directories appear first (lower specificity), entries from closer directories appear last (higher specificity, stronger recency in the LLM prompt).
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -13,7 +13,7 @@ Reads agent hook input from stdin, resolves matching context entries, and writes
 echo '{"tool_name":"Edit","tool_input":{"file_path":"/project/src/main.py"},"hook_event_name":"PreToolUse"}' | sctx hook
 ```
 
-Currently supports Claude Code's JSON format. The adapter reads `tool_name`, `tool_input.file_path`, and `hook_event_name` from stdin, resolves context, and outputs Claude Code's expected `hookSpecificOutput` JSON.
+Currently supports Claude Code's JSON format. The adapter reads `tool_name`, `tool_input.file_path`, `hook_event_name`, and `cwd` from stdin, resolves context, and outputs Claude Code's expected `hookSpecificOutput` JSON. The `cwd` field determines the project root — only `AGENTS.yaml` files at or below this directory are considered.
 
 Only context entries are included in hook output. Decisions are excluded to keep token costs low. Use `sctx decisions` to query decisions separately.
 
@@ -23,7 +23,7 @@ The Write tool gets special treatment: `sctx` checks whether the target file exi
 
 ## sctx context \<path\>
 
-Query context entries for a file. Useful for debugging and testing your context files.
+Query context entries for a file. Useful for debugging and testing your context files. The current working directory is used as the project root — only `AGENTS.yaml` files at or below it are considered.
 
 ```bash
 sctx context src/api/handler.py

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -24,9 +24,14 @@ If multiple context files exist in the same directory, all are loaded and their 
 
 Context files can appear in any directory. Tools discover them by walking up from the target file to the project root, collecting every context file found along the way.
 
-### Project root detection
+### Project root
 
-The project root is identified by the presence of any of these markers: `.git`, `go.mod`, `package.json`, `Cargo.toml`, `pyproject.toml`, `Makefile`. If no marker is found, the directory containing the target file is used as the root.
+The project root is the working directory where the tool was launched — not detected via file markers. This is deliberate: marker-based detection (`.git`, `pyproject.toml`, etc.) breaks in monorepos where subdirectories contain their own project markers.
+
+- **Hook mode** (`sctx hook`): The root is the `cwd` field from the agent's JSON input. For Claude Code, this is the directory where `claude` was started.
+- **CLI mode** (`sctx context`, `sctx decisions`): The root is the current working directory where `sctx` is run.
+
+Only `AGENTS.yaml` files at or below the root are considered. Files above the root are never seen.
 
 ### Missing files
 
@@ -155,7 +160,7 @@ Decisions are made under constraints. When constraints change, the decision may 
 
 Given a file path, an action, and a timing:
 
-1. **Discover** -- Walk from the target file's directory up to the project root, collecting all context files at each level
+1. **Discover** -- Walk from the target file's directory up to the project root (the working directory), collecting all context files at each level
 2. **Parse** -- Parse each file. Emit warnings for invalid files but continue processing valid ones
 3. **Filter by match/exclude** -- Test each entry's glob patterns against the target file path. Globs are relative to the context file's directory
 4. **Filter by action** -- Keep entries where `on` includes the requested action (or is `all`)

--- a/internal/adapter/claude.go
+++ b/internal/adapter/claude.go
@@ -77,6 +77,7 @@ func HandleClaudeHook(input []byte) error {
 		FilePath: toolInput.FilePath,
 		Action:   action,
 		Timing:   timing,
+		Root:     hookInput.CWD,
 	})
 	if err != nil {
 		return fmt.Errorf("resolving context: %w", err)

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -24,7 +24,14 @@ func Resolve(req ResolveRequest) (*ResolveResult, []string, error) {
 		return nil, nil, fmt.Errorf("resolving absolute path: %w", err)
 	}
 
-	root := findProjectRoot(filepath.Dir(absPath))
+	root := req.Root
+	if root == "" {
+		root, err = os.Getwd()
+		if err != nil {
+			return nil, nil, fmt.Errorf("getting working directory: %w", err)
+		}
+	}
+
 	files, warnings := discoverAndParse(filepath.Dir(absPath), root)
 
 	result := &ResolveResult{}
@@ -38,27 +45,6 @@ func Resolve(req ResolveRequest) (*ResolveResult, []string, error) {
 	}
 
 	return result, warnings, nil
-}
-
-// findProjectRoot walks up from dir looking for common project root markers.
-func findProjectRoot(dir string) string {
-	markers := []string{".git", "go.mod", "package.json", "Cargo.toml", "pyproject.toml", "Makefile"}
-	current := dir
-
-	for {
-		for _, marker := range markers {
-			if _, err := os.Stat(filepath.Join(current, marker)); err == nil {
-				return current
-			}
-		}
-
-		parent := filepath.Dir(current)
-		if parent == current {
-			return dir
-		}
-
-		current = parent
-	}
 }
 
 // discoverAndParse walks from startDir up to root, collecting and parsing all

--- a/internal/core/engine_test.go
+++ b/internal/core/engine_test.go
@@ -132,12 +132,14 @@ func TestMatchesAction(t *testing.T) {
 
 func TestResolve_EditBefore(t *testing.T) {
 	td := testdataDir(t)
-	target := filepath.Join(td, "project", "src", "api", "handler.py")
+	root := filepath.Join(td, "project")
+	target := filepath.Join(root, "src", "api", "handler.py")
 
 	result, _, err := Resolve(ResolveRequest{
 		FilePath: target,
 		Action:   ActionEdit,
 		Timing:   TimingBefore,
+		Root:     root,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -154,12 +156,14 @@ func TestResolve_EditBefore(t *testing.T) {
 
 func TestResolve_EditAfter(t *testing.T) {
 	td := testdataDir(t)
-	target := filepath.Join(td, "project", "src", "api", "handler.py")
+	root := filepath.Join(td, "project")
+	target := filepath.Join(root, "src", "api", "handler.py")
 
 	result, _, err := Resolve(ResolveRequest{
 		FilePath: target,
 		Action:   ActionEdit,
 		Timing:   TimingAfter,
+		Root:     root,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -176,12 +180,14 @@ func TestResolve_EditAfter(t *testing.T) {
 
 func TestResolve_ExcludePattern(t *testing.T) {
 	td := testdataDir(t)
-	target := filepath.Join(td, "project", "src", "api", "handler_test.py")
+	root := filepath.Join(td, "project")
+	target := filepath.Join(root, "src", "api", "handler_test.py")
 
 	result, _, err := Resolve(ResolveRequest{
 		FilePath: target,
 		Action:   ActionEdit,
 		Timing:   TimingAfter,
+		Root:     root,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -195,12 +201,14 @@ func TestResolve_ExcludePattern(t *testing.T) {
 
 func TestResolve_CreateAction(t *testing.T) {
 	td := testdataDir(t)
-	target := filepath.Join(td, "project", "src", "api", "new_handler.py")
+	root := filepath.Join(td, "project")
+	target := filepath.Join(root, "src", "api", "new_handler.py")
 
 	result, _, err := Resolve(ResolveRequest{
 		FilePath: target,
 		Action:   ActionCreate,
 		Timing:   TimingBefore,
+		Root:     root,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -219,12 +227,14 @@ func TestResolve_CreateAction(t *testing.T) {
 
 func TestResolve_ReadDoesNotMatchEditOnly(t *testing.T) {
 	td := testdataDir(t)
-	target := filepath.Join(td, "project", "src", "api", "handler.py")
+	root := filepath.Join(td, "project")
+	target := filepath.Join(root, "src", "api", "handler.py")
 
 	result, _, err := Resolve(ResolveRequest{
 		FilePath: target,
 		Action:   ActionRead,
 		Timing:   TimingBefore,
+		Root:     root,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -238,12 +248,14 @@ func TestResolve_ReadDoesNotMatchEditOnly(t *testing.T) {
 
 func TestResolve_NonPythonFile(t *testing.T) {
 	td := testdataDir(t)
-	target := filepath.Join(td, "project", "README.md")
+	root := filepath.Join(td, "project")
+	target := filepath.Join(root, "README.md")
 
 	result, _, err := Resolve(ResolveRequest{
 		FilePath: target,
 		Action:   ActionEdit,
 		Timing:   TimingBefore,
+		Root:     root,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -257,12 +269,14 @@ func TestResolve_NonPythonFile(t *testing.T) {
 
 func TestResolve_Decisions(t *testing.T) {
 	td := testdataDir(t)
-	target := filepath.Join(td, "project", "src", "api", "handler.py")
+	root := filepath.Join(td, "project")
+	target := filepath.Join(root, "src", "api", "handler.py")
 
 	result, _, err := Resolve(ResolveRequest{
 		FilePath: target,
 		Action:   ActionEdit,
 		Timing:   TimingBefore,
+		Root:     root,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -278,7 +292,6 @@ func TestResolve_Decisions(t *testing.T) {
 
 func TestResolve_MergesMultipleFileNames(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
 	writeTestFile(t, filepath.Join(tmpDir, "AGENTS.yaml"), `
 context:
   - content: "From AGENTS.yaml"
@@ -295,6 +308,7 @@ context:
 		FilePath: target,
 		Action:   ActionRead,
 		Timing:   TimingBefore,
+		Root:     tmpDir,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -306,7 +320,6 @@ context:
 
 func TestResolve_NoContextFiles(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
 
 	target := filepath.Join(tmpDir, "file.txt")
 	writeTestFile(t, target, "")
@@ -315,6 +328,7 @@ func TestResolve_NoContextFiles(t *testing.T) {
 		FilePath: target,
 		Action:   ActionRead,
 		Timing:   TimingBefore,
+		Root:     tmpDir,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -339,7 +353,6 @@ func TestResolve_NoContextFiles(t *testing.T) {
 
 func TestResolve_AllActionAllTimingReturnsEverything(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
 	writeTestFile(t, filepath.Join(tmpDir, "AGENTS.yaml"), `
 context:
   - content: "before-all"
@@ -363,6 +376,7 @@ context:
 		FilePath: target,
 		Action:   ActionAll,
 		Timing:   TimingAll,
+		Root:     tmpDir,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -378,7 +392,6 @@ context:
 
 func TestResolve_AllActionSpecificTiming(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
 	writeTestFile(t, filepath.Join(tmpDir, "AGENTS.yaml"), `
 context:
   - content: "before-all"
@@ -400,6 +413,7 @@ context:
 		FilePath: target,
 		Action:   ActionAll,
 		Timing:   TimingBefore,
+		Root:     tmpDir,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -413,7 +427,6 @@ context:
 
 func TestResolve_SpecificActionAllTiming(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
 	writeTestFile(t, filepath.Join(tmpDir, "AGENTS.yaml"), `
 context:
   - content: "before-all"
@@ -435,6 +448,7 @@ context:
 		FilePath: target,
 		Action:   ActionEdit,
 		Timing:   TimingAll,
+		Root:     tmpDir,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -455,14 +469,49 @@ func writeTestFile(t *testing.T, path, content string) {
 	}
 }
 
+func TestResolve_ContextAboveRootIsIgnored(t *testing.T) {
+	parentDir := t.TempDir()
+	writeTestFile(t, filepath.Join(parentDir, "AGENTS.yaml"), `
+context:
+  - content: "From above root"
+`)
+
+	childDir := filepath.Join(parentDir, "child")
+	if err := os.MkdirAll(childDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	writeTestFile(t, filepath.Join(childDir, "AGENTS.yaml"), `
+context:
+  - content: "From child root"
+`)
+
+	target := filepath.Join(childDir, "file.txt")
+	writeTestFile(t, target, "")
+
+	result, _, err := Resolve(ResolveRequest{
+		FilePath: target,
+		Action:   ActionAll,
+		Timing:   TimingAll,
+		Root:     childDir,
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+
+	assertContextContents(t, result.ContextEntries, []string{"From child root"})
+}
+
 func TestResolve_ParentBeforeChild(t *testing.T) {
 	td := testdataDir(t)
-	target := filepath.Join(td, "project", "src", "api", "handler.py")
+	root := filepath.Join(td, "project")
+	target := filepath.Join(root, "src", "api", "handler.py")
 
 	result, _, err := Resolve(ResolveRequest{
 		FilePath: target,
 		Action:   ActionEdit,
 		Timing:   TimingBefore,
+		Root:     root,
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error: %v", err)
@@ -556,7 +605,6 @@ func writeAgentsYAML(t *testing.T, dir string, entries []ContextEntry) {
 func TestResolve_NeverPanics(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		tmpDir := t.TempDir()
-		writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
 
 		depth := rapid.IntRange(0, 3).Draw(rt, "depth")
 		dir := tmpDir
@@ -614,6 +662,7 @@ func TestResolve_NeverPanics(t *testing.T) {
 			FilePath: target,
 			Action:   action,
 			Timing:   timing,
+			Root:     tmpDir,
 		})
 	})
 }
@@ -621,7 +670,6 @@ func TestResolve_NeverPanics(t *testing.T) {
 func TestResolve_ChildMergesWithParent(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		tmpDir := t.TempDir()
-		writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
 
 		parentContent := rapid.StringMatching(`[a-z]{5,15}`).Draw(rt, "parentContent")
 		childContent := rapid.StringMatching(`[a-z]{5,15}`).Draw(rt, "childContent")
@@ -646,6 +694,7 @@ func TestResolve_ChildMergesWithParent(t *testing.T) {
 			FilePath: target,
 			Action:   ActionRead,
 			Timing:   TimingBefore,
+			Root:     tmpDir,
 		})
 		if err != nil {
 			t.Fatalf("Resolve() error: %v", err)
@@ -675,7 +724,6 @@ func TestResolve_ChildMergesWithParent(t *testing.T) {
 func TestResolve_ExcludeOverridesMatch(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		tmpDir := t.TempDir()
-		writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
 
 		ext := rapid.SampledFrom([]string{".go", ".py", ".js", ".txt", ".md"}).Draw(rt, "ext")
 		globPattern := "**/*" + ext
@@ -698,6 +746,7 @@ func TestResolve_ExcludeOverridesMatch(t *testing.T) {
 			FilePath: target,
 			Action:   ActionRead,
 			Timing:   TimingBefore,
+			Root:     tmpDir,
 		})
 		if err != nil {
 			t.Fatalf("Resolve() error: %v", err)
@@ -714,7 +763,6 @@ func TestResolve_ExcludeOverridesMatch(t *testing.T) {
 func TestResolve_EditEntriesFilteredForActionRead(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		tmpDir := t.TempDir()
-		writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
 
 		editContent := rapid.StringMatching(`editonly-[a-z]{5,10}`).Draw(rt, "editContent")
 		when := genWhenValue(rt)
@@ -742,6 +790,7 @@ func TestResolve_EditEntriesFilteredForActionRead(t *testing.T) {
 			FilePath: target,
 			Action:   ActionRead,
 			Timing:   Timing(when),
+			Root:     tmpDir,
 		})
 		if err != nil {
 			t.Fatalf("Resolve() error: %v", err)
@@ -758,7 +807,6 @@ func TestResolve_EditEntriesFilteredForActionRead(t *testing.T) {
 func TestResolve_ParentBeforeChildOrdering(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		tmpDir := t.TempDir()
-		writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
 
 		depth := rapid.IntRange(1, 4).Draw(rt, "depth")
 		dirs := []string{tmpDir}
@@ -785,6 +833,7 @@ func TestResolve_ParentBeforeChildOrdering(t *testing.T) {
 			FilePath: target,
 			Action:   ActionRead,
 			Timing:   TimingBefore,
+			Root:     tmpDir,
 		})
 		if err != nil {
 			t.Fatalf("Resolve() error: %v", err)
@@ -835,7 +884,6 @@ func TestResolve_MalformedYAMLGracefulDegradation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			writeTestFile(t, filepath.Join(tmpDir, ".git"), "")
 			writeTestFile(t, filepath.Join(tmpDir, "AGENTS.yaml"), tt.rootYAML)
 
 			childDir := filepath.Join(tmpDir, "child")
@@ -852,6 +900,7 @@ func TestResolve_MalformedYAMLGracefulDegradation(t *testing.T) {
 				FilePath: target,
 				Action:   ActionRead,
 				Timing:   TimingBefore,
+				Root:     tmpDir,
 			})
 			if err != nil {
 				t.Fatalf("Resolve() error: %v", err)

--- a/internal/core/schema.go
+++ b/internal/core/schema.go
@@ -82,6 +82,7 @@ type ResolveRequest struct {
 	FilePath string
 	Action   Action
 	Timing   Timing
+	Root     string // Project root directory; walk stops here.
 }
 
 // ResolveResult contains the matched context and decisions for a request.


### PR DESCRIPTION
## Summary

Fixes #44. `findProjectRoot` was walking up from the target file looking for markers like `.git`, `pyproject.toml`, `Makefile`, etc. In monorepos where a subdirectory has its own `pyproject.toml`, it'd stop there and never reach the actual root. So the root `AGENTS.yaml` just vanished.

The fix: stop guessing. Use the working directory instead of marker detection.

- **Hook mode** (`sctx hook`): uses the `cwd` field from Claude Code's JSON input, which is the directory where `claude` was launched
- **CLI mode** (`sctx context`, `sctx decisions`): uses `os.Getwd()`, so wherever you run `sctx` from is the root

`findProjectRoot` is deleted entirely. No fallback to markers. The root is always explicit and predictable.

Changes:
- Added `Root` field to `ResolveRequest`
- `Resolve()` uses `req.Root` when set, falls back to `os.Getwd()`
- Claude adapter passes `hookInput.CWD` as `Root`
- Removed `findProjectRoot()` and all `.git` marker files from tests
- Updated protocol.md, README, and cli-reference docs